### PR TITLE
Provided property is not present

### DIFF
--- a/jobs/metric-store/spec
+++ b/jobs/metric-store/spec
@@ -16,7 +16,6 @@ provides:
   properties:
   - port
   - tls
-  - disabled
 
 consumes:
 - name: metric-store


### PR DESCRIPTION
disabled is not a property available in the properties list. This causes the following error while deploying with Bosh:

```
Task 206930 | 17:31:49 | Preparing deployment: Preparing deployment (00:00:03)
                      L Error: Link property disabled in template metric-store is not defined in release spec
Task 206930 | 17:31:52 | Error: Link property disabled in template metric-store is not defined in release spec
```