### PR TITLE
leanstreams always sends 8 bytes for the header

### DIFF
--- a/src/pkg/leanstreams/leanstreams_test.go
+++ b/src/pkg/leanstreams/leanstreams_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Leanstreams", func() {
 		defer cleanup()
 
 		n, err := tc.Write("This is an example message")
-		Expect(n).To(Equal(54))
+		Expect(n).To(Equal(60))
 		Expect(err).ToNot(HaveOccurred())
 		tc.WaitForResults()
 
@@ -141,13 +141,13 @@ var _ = Describe("Leanstreams", func() {
 			defer cleanup()
 
 			n, err := tc.Write(randStr(200))
-			Expect(n).To(Equal(229))
+			Expect(n).To(Equal(235))
 			Expect(err).ToNot(HaveOccurred())
 
 			time.Sleep(time.Second)
 
 			n, err = tc.Write("This is an example message")
-			Expect(n).To(Equal(54))
+			Expect(n).To(Equal(60))
 			Expect(err).ToNot(HaveOccurred())
 			tc.WaitForResults()
 
@@ -167,7 +167,7 @@ var _ = Describe("Leanstreams", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			messageSize, err := tc.Write("This is an example message")
-			Expect(messageSize).To(Equal(54))
+			Expect(messageSize).To(Equal(60))
 			Expect(err).ToNot(HaveOccurred())
 			tc.WaitForResults()
 

--- a/src/pkg/leanstreams/tcpclient.go
+++ b/src/pkg/leanstreams/tcpclient.go
@@ -45,8 +45,6 @@ func newTCPClient(cfg *TCPClientConfig) *TCPClient {
 		maxMessageSize = cfg.MaxMessageSize
 	}
 
-	headerByteSize := messageSizeToBitLength(maxMessageSize)
-
 	return &TCPClient{
 		MaxMessageSize:       maxMessageSize,
 		headerByteSize:       headerByteSize,
@@ -112,8 +110,8 @@ func (c *TCPClient) Close() error {
 func (c *TCPClient) write(data []byte) (int, error) {
 	// Calculate how big the message is, using a consistent header size.
 	// Append the size to the message, so now it has a header
-	c.outgoingDataBuffer = append(intToByteArray(int64(len(data)), c.headerByteSize), data...)
-	emptyBuffer := append(intToByteArray(int64(len([]byte(""))), c.headerByteSize), []byte("")...)
+	c.outgoingDataBuffer = append(int64ToByteArray(int64(len(data)), c.headerByteSize), data...)
+	emptyBuffer := append(int64ToByteArray(int64(len([]byte(""))), c.headerByteSize), []byte("")...)
 
 	toWriteLen := len(c.outgoingDataBuffer)
 

--- a/src/pkg/leanstreams/tcpserver.go
+++ b/src/pkg/leanstreams/tcpserver.go
@@ -9,6 +9,10 @@ import (
 	"sync"
 )
 
+const (
+	headerByteSize = 8
+)
+
 var (
 	// ErrZeroBytesReadHeader is thrown when the value parsed from the header is not valid
 	ErrZeroBytesReadHeader = errors.New("0 Bytes parsed from header. Connection Closed")
@@ -53,8 +57,6 @@ func newTCPServer(cfg *TCPServerConfig) *TCPServer {
 	if cfg.MaxMessageSize != 0 {
 		maxMessageSize = cfg.MaxMessageSize
 	}
-
-	headerByteSize := messageSizeToBitLength(maxMessageSize)
 
 	return &TCPServer{
 		MaxMessageSize:       maxMessageSize,
@@ -112,7 +114,7 @@ func (c *TCPServer) Read(b []byte) (int, error) {
 		return hLength, err
 	}
 	// Decode it
-	msgLength, bytesParsed := byteArrayToUInt32(c.incomingHeaderBuffer)
+	msgLength, bytesParsed := byteArrayToInt64(c.incomingHeaderBuffer)
 	if bytesParsed == 0 {
 		// "Buffer too small"
 		c.Close()

--- a/src/pkg/leanstreams/util.go
+++ b/src/pkg/leanstreams/util.go
@@ -5,11 +5,11 @@ import (
 	"math"
 )
 
-func byteArrayToUInt32(bytes []byte) (result int64, bytesRead int) {
+func byteArrayToInt64(bytes []byte) (result int64, bytesRead int) {
 	return binary.Varint(bytes)
 }
 
-func intToByteArray(value int64, bufferSize int) []byte {
+func int64ToByteArray(value int64, bufferSize int) []byte {
 	toWriteLen := make([]byte, bufferSize)
 	binary.PutVarint(toWriteLen, value)
 	return toWriteLen

--- a/src/pkg/leanstreams/util_test.go
+++ b/src/pkg/leanstreams/util_test.go
@@ -52,8 +52,8 @@ func TestMessageBytesToInt(t *testing.T) {
 
 	for _, c := range cases {
 		byteSize := messageSizeToBitLength(int(c.input))
-		bytes := intToByteArray(c.input, byteSize)
-		result, _ := byteArrayToUInt32(bytes)
+		bytes := int64ToByteArray(c.input, byteSize)
+		result, _ := byteArrayToInt64(bytes)
 		if result != c.output {
 			t.Errorf("Conversion between bytes incorrect. Original value %d, got %d", c.input, result)
 		}


### PR DESCRIPTION
The message length header is an int64 and leanstreams was trying to
send as few of bytes possible for the header. This was causing us to
receive an EOF error any time we set the MaxMessageSize to a number
greater than 65535.

This commit changes leanstreams to always send 8 bytes for the int64
header.