### PR TITLE
Auto Bump Dependencies 2020-02-03-000050

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/tinylib/msgp v1.1.1 // indirect
 	github.com/willf/bitset v1.1.10 // indirect
 	go.uber.org/zap v1.13.0
-	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	google.golang.org/grpc v1.24.0
 	gopkg.in/yaml.v2 v2.2.8

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	code.cloudfoundry.org/go-diodes v0.0.0-20190809170250-f77fb823c7ee
 	code.cloudfoundry.org/go-envstruct v1.5.0
 	code.cloudfoundry.org/go-loggregator v0.0.0-20190725203007-b8d176783c8a
-	code.cloudfoundry.org/tlsconfig v0.0.0-20200125003142-b5ccaa4fedfc
+	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3
 	collectd.org v0.3.0 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20200121172959-3c452dc2b12a // indirect
 	github.com/benbjohnson/jmphash v0.0.0-20141216154655-2d58f234cd86

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/willf/bitset v1.1.10 // indirect
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
-	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 	google.golang.org/grpc v1.24.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -589,8 +589,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa h1:F+8P+gmewFQYRk6JoLQLwjBCTu3mcIURZfNkVweuRKA=
-golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/go.sum
+++ b/go.sum
@@ -626,8 +626,8 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ code.cloudfoundry.org/go-loggregator v0.0.0-20190725203007-b8d176783c8a h1:QsW5T
 code.cloudfoundry.org/go-loggregator v0.0.0-20190725203007-b8d176783c8a/go.mod h1:1mwOFhAA8/glYCFDxiqKchLJsNtGScQAkd4zEFxgPwA=
 code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a h1:8rqv2w8xEceNwckcF5ONeRt0qBHlh5bnNfFnYTrZbxs=
 code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a/go.mod h1:tkZo8GtzBjySJ7USvxm4E36lNQw1D3xM6oKHGqdaAJ4=
-code.cloudfoundry.org/tlsconfig v0.0.0-20200125003142-b5ccaa4fedfc h1:8z9myVbPAX9H3Qf6rmNIoMTutd1PFQYBtAwQmZr+spg=
-code.cloudfoundry.org/tlsconfig v0.0.0-20200125003142-b5ccaa4fedfc/go.mod h1:eTbFJpyXRGuFVyg5+oaj9B2eIbIc+0/kZjH8ftbtdew=
+code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 h1:2Qal+q+tw/DmDOoJBWwDCPE3lIJNj/1o7oMkkb2c5SI=
+code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3/go.mod h1:eTbFJpyXRGuFVyg5+oaj9B2eIbIc+0/kZjH8ftbtdew=
 collectd.org v0.3.0 h1:iNBHGw1VvPJxH2B6RiFWFZ+vsjo1lCdRszBeOuwGi00=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 contrib.go.opencensus.io/exporter/ocagent v0.6.0 h1:Z1n6UAyr0QwM284yUuh5Zd8JlvxUGAhFZcgMJkMPrGM=

--- a/vendor/golang.org/x/net/html/node.go
+++ b/vendor/golang.org/x/net/html/node.go
@@ -18,6 +18,11 @@ const (
 	ElementNode
 	CommentNode
 	DoctypeNode
+	// RawNode nodes are not returned by the parser, but can be part of the
+	// Node tree passed to func Render to insert raw HTML (without escaping).
+	// If so, this package makes no guarantee that the rendered HTML is secure
+	// (from e.g. Cross Site Scripting attacks) or well-formed.
+	RawNode
 	scopeMarkerNode
 )
 

--- a/vendor/golang.org/x/net/html/render.go
+++ b/vendor/golang.org/x/net/html/render.go
@@ -134,6 +134,9 @@ func render1(w writer, n *Node) error {
 			}
 		}
 		return w.WriteByte('>')
+	case RawNode:
+		_, err := w.WriteString(n.Data)
+		return err
 	default:
 		return errors.New("html: unknown node type")
 	}

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -716,8 +719,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -747,7 +751,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1229,6 +1233,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1241,6 +1246,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1583,6 +1589,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x40042406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x2405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x4004743d
 	PPPIOCATTCHAN                               = 0x40047438
 	PPPIOCCONNECT                               = 0x4004743a
@@ -1593,6 +1600,8 @@ const (
 	PPPIOCGDEBUG                                = 0x80047441
 	PPPIOCGFLAGS                                = 0x8004745a
 	PPPIOCGIDLE                                 = 0x8008743f
+	PPPIOCGIDLE32                               = 0x8008743f
+	PPPIOCGIDLE64                               = 0x8010743f
 	PPPIOCGL2TPSTATS                            = 0x80487436
 	PPPIOCGMRU                                  = 0x80047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1935,6 +1944,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1958,6 +1968,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1971,13 +1982,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1992,8 +2004,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2208,7 +2220,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2314,6 +2326,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2434,6 +2447,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2530,6 +2544,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2562,6 +2580,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -716,8 +719,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -747,7 +751,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1229,6 +1233,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1241,6 +1246,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1583,6 +1589,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x40082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x2405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x4004743d
 	PPPIOCATTCHAN                               = 0x40047438
 	PPPIOCCONNECT                               = 0x4004743a
@@ -1593,6 +1600,8 @@ const (
 	PPPIOCGDEBUG                                = 0x80047441
 	PPPIOCGFLAGS                                = 0x8004745a
 	PPPIOCGIDLE                                 = 0x8010743f
+	PPPIOCGIDLE32                               = 0x8008743f
+	PPPIOCGIDLE64                               = 0x8010743f
 	PPPIOCGL2TPSTATS                            = 0x80487436
 	PPPIOCGMRU                                  = 0x80047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1936,6 +1945,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1959,6 +1969,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1972,13 +1983,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1993,8 +2005,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2209,7 +2221,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2315,6 +2327,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2435,6 +2448,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2531,6 +2545,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2563,6 +2581,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x40042406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x2405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x4004743d
 	PPPIOCATTCHAN                               = 0x40047438
 	PPPIOCCONNECT                               = 0x4004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x80047441
 	PPPIOCGFLAGS                                = 0x8004745a
 	PPPIOCGIDLE                                 = 0x8008743f
+	PPPIOCGIDLE32                               = 0x8008743f
+	PPPIOCGIDLE64                               = 0x8010743f
 	PPPIOCGL2TPSTATS                            = 0x80487436
 	PPPIOCGMRU                                  = 0x80047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1942,6 +1951,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1965,6 +1975,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1978,13 +1989,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1999,8 +2011,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2215,7 +2227,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2321,6 +2333,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2441,6 +2454,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2537,6 +2551,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2569,6 +2587,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -718,8 +721,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -749,7 +753,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1231,6 +1235,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1243,6 +1248,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1584,6 +1590,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x40082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x2405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x4004743d
 	PPPIOCATTCHAN                               = 0x40047438
 	PPPIOCCONNECT                               = 0x4004743a
@@ -1594,6 +1601,8 @@ const (
 	PPPIOCGDEBUG                                = 0x80047441
 	PPPIOCGFLAGS                                = 0x8004745a
 	PPPIOCGIDLE                                 = 0x8010743f
+	PPPIOCGIDLE32                               = 0x8008743f
+	PPPIOCGIDLE64                               = 0x8010743f
 	PPPIOCGL2TPSTATS                            = 0x80487436
 	PPPIOCGMRU                                  = 0x80047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1928,6 +1937,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1951,6 +1961,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1964,13 +1975,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1985,8 +1997,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2201,7 +2213,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2307,6 +2319,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2428,6 +2441,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2524,6 +2538,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2556,6 +2574,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80042406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4008743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1935,6 +1944,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1958,6 +1968,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1971,13 +1982,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1992,8 +2004,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2208,7 +2220,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1009
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2315,6 +2327,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2434,6 +2447,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2532,6 +2546,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2564,6 +2582,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4010743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1935,6 +1944,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1958,6 +1968,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1971,13 +1982,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1992,8 +2004,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2208,7 +2220,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1009
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2315,6 +2327,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2434,6 +2447,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2532,6 +2546,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2564,6 +2582,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4010743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1935,6 +1944,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1958,6 +1968,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1971,13 +1982,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1992,8 +2004,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2208,7 +2220,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1009
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2315,6 +2327,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2434,6 +2447,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2532,6 +2546,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2564,6 +2582,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80042406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4008743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1935,6 +1944,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1958,6 +1968,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1971,13 +1982,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1992,8 +2004,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2208,7 +2220,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1009
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2315,6 +2327,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2434,6 +2447,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2532,6 +2546,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2564,6 +2582,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1265,6 +1271,7 @@ const (
 	MAP_SHARED                                  = 0x1
 	MAP_SHARED_VALIDATE                         = 0x3
 	MAP_STACK                                   = 0x20000
+	MAP_SYNC                                    = 0x80000
 	MAP_TYPE                                    = 0xf
 	MCAST_BLOCK_SOURCE                          = 0x2b
 	MCAST_EXCLUDE                               = 0x0
@@ -1582,6 +1589,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1592,6 +1600,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4010743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1993,6 +2003,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -2016,6 +2027,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -2029,13 +2041,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -2050,8 +2063,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2266,7 +2279,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2372,6 +2385,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2490,6 +2504,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2592,6 +2607,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2624,6 +2643,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1265,6 +1271,7 @@ const (
 	MAP_SHARED                                  = 0x1
 	MAP_SHARED_VALIDATE                         = 0x3
 	MAP_STACK                                   = 0x20000
+	MAP_SYNC                                    = 0x80000
 	MAP_TYPE                                    = 0xf
 	MCAST_BLOCK_SOURCE                          = 0x2b
 	MCAST_EXCLUDE                               = 0x0
@@ -1582,6 +1589,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1592,6 +1600,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4010743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1993,6 +2003,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -2016,6 +2027,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -2029,13 +2041,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -2050,8 +2063,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2266,7 +2279,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2372,6 +2385,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2490,6 +2504,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2592,6 +2607,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2624,6 +2643,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x40082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x2405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x4004743d
 	PPPIOCATTCHAN                               = 0x40047438
 	PPPIOCCONNECT                               = 0x4004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x80047441
 	PPPIOCGFLAGS                                = 0x8004745a
 	PPPIOCGIDLE                                 = 0x8010743f
+	PPPIOCGIDLE32                               = 0x8008743f
+	PPPIOCGIDLE64                               = 0x8010743f
 	PPPIOCGL2TPSTATS                            = 0x80487436
 	PPPIOCGMRU                                  = 0x80047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1923,6 +1932,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -1946,6 +1956,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -1959,13 +1970,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -1980,8 +1992,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2196,7 +2208,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2302,6 +2314,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2422,6 +2435,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2518,6 +2532,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2550,6 +2568,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
@@ -243,6 +243,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -417,8 +418,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -715,8 +718,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -746,7 +750,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1228,6 +1232,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1240,6 +1245,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1581,6 +1587,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x40082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x2405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x4004743d
 	PPPIOCATTCHAN                               = 0x40047438
 	PPPIOCCONNECT                               = 0x4004743a
@@ -1591,6 +1598,8 @@ const (
 	PPPIOCGDEBUG                                = 0x80047441
 	PPPIOCGFLAGS                                = 0x8004745a
 	PPPIOCGIDLE                                 = 0x8010743f
+	PPPIOCGIDLE32                               = 0x8008743f
+	PPPIOCGIDLE64                               = 0x8010743f
 	PPPIOCGL2TPSTATS                            = 0x80487436
 	PPPIOCGMRU                                  = 0x80047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1996,6 +2005,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -2019,6 +2029,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -2032,13 +2043,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -2053,8 +2065,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2269,7 +2281,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x1e
 	SO_ATTACH_BPF                               = 0x32
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2375,6 +2387,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2495,6 +2508,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2591,6 +2605,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2623,6 +2641,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
@@ -246,6 +246,7 @@ const (
 	BPF_F_LOCK                                  = 0x4
 	BPF_F_MARK_ENFORCE                          = 0x40
 	BPF_F_MARK_MANGLED_0                        = 0x20
+	BPF_F_MMAPABLE                              = 0x400
 	BPF_F_NO_COMMON_LRU                         = 0x2
 	BPF_F_NO_PREALLOC                           = 0x1
 	BPF_F_NUMA_NODE                             = 0x4
@@ -420,8 +421,10 @@ const (
 	CLOCK_TXFROMRX                              = 0x4
 	CLOCK_TXINT                                 = 0x3
 	CLONE_ARGS_SIZE_VER0                        = 0x40
+	CLONE_ARGS_SIZE_VER1                        = 0x50
 	CLONE_CHILD_CLEARTID                        = 0x200000
 	CLONE_CHILD_SETTID                          = 0x1000000
+	CLONE_CLEAR_SIGHAND                         = 0x100000000
 	CLONE_DETACHED                              = 0x400000
 	CLONE_FILES                                 = 0x400
 	CLONE_FS                                    = 0x200
@@ -719,8 +722,9 @@ const (
 	FSCRYPT_POLICY_FLAGS_PAD_4                  = 0x0
 	FSCRYPT_POLICY_FLAGS_PAD_8                  = 0x1
 	FSCRYPT_POLICY_FLAGS_PAD_MASK               = 0x3
-	FSCRYPT_POLICY_FLAGS_VALID                  = 0x7
+	FSCRYPT_POLICY_FLAGS_VALID                  = 0xf
 	FSCRYPT_POLICY_FLAG_DIRECT_KEY              = 0x4
+	FSCRYPT_POLICY_FLAG_IV_INO_LBLK_64          = 0x8
 	FSCRYPT_POLICY_V1                           = 0x0
 	FSCRYPT_POLICY_V2                           = 0x2
 	FS_ENCRYPTION_MODE_ADIANTUM                 = 0x9
@@ -750,7 +754,7 @@ const (
 	FS_POLICY_FLAGS_PAD_4                       = 0x0
 	FS_POLICY_FLAGS_PAD_8                       = 0x1
 	FS_POLICY_FLAGS_PAD_MASK                    = 0x3
-	FS_POLICY_FLAGS_VALID                       = 0x7
+	FS_POLICY_FLAGS_VALID                       = 0xf
 	FUTEXFS_SUPER_MAGIC                         = 0xbad1dea
 	F_ADD_SEALS                                 = 0x409
 	F_DUPFD                                     = 0x0
@@ -1232,6 +1236,7 @@ const (
 	LOOP_SET_STATUS64                           = 0x4c04
 	LO_KEY_SIZE                                 = 0x20
 	LO_NAME_SIZE                                = 0x40
+	MADV_COLD                                   = 0x14
 	MADV_DODUMP                                 = 0x11
 	MADV_DOFORK                                 = 0xb
 	MADV_DONTDUMP                               = 0x10
@@ -1244,6 +1249,7 @@ const (
 	MADV_MERGEABLE                              = 0xc
 	MADV_NOHUGEPAGE                             = 0xf
 	MADV_NORMAL                                 = 0x0
+	MADV_PAGEOUT                                = 0x15
 	MADV_RANDOM                                 = 0x1
 	MADV_REMOVE                                 = 0x9
 	MADV_SEQUENTIAL                             = 0x2
@@ -1270,6 +1276,7 @@ const (
 	MAP_SHARED                                  = 0x1
 	MAP_SHARED_VALIDATE                         = 0x3
 	MAP_STACK                                   = 0x20000
+	MAP_SYNC                                    = 0x80000
 	MAP_TYPE                                    = 0xf
 	MCAST_BLOCK_SOURCE                          = 0x2b
 	MCAST_EXCLUDE                               = 0x0
@@ -1585,6 +1592,7 @@ const (
 	PERF_EVENT_IOC_SET_FILTER                   = 0x80082406
 	PERF_EVENT_IOC_SET_OUTPUT                   = 0x20002405
 	PIPEFS_MAGIC                                = 0x50495045
+	PPC_CMM_MAGIC                               = 0xc7571590
 	PPPIOCATTACH                                = 0x8004743d
 	PPPIOCATTCHAN                               = 0x80047438
 	PPPIOCCONNECT                               = 0x8004743a
@@ -1595,6 +1603,8 @@ const (
 	PPPIOCGDEBUG                                = 0x40047441
 	PPPIOCGFLAGS                                = 0x4004745a
 	PPPIOCGIDLE                                 = 0x4010743f
+	PPPIOCGIDLE32                               = 0x4008743f
+	PPPIOCGIDLE64                               = 0x4010743f
 	PPPIOCGL2TPSTATS                            = 0x40487436
 	PPPIOCGMRU                                  = 0x40047453
 	PPPIOCGNPMODE                               = 0xc008744c
@@ -1988,6 +1998,7 @@ const (
 	RTM_DELADDRLABEL                            = 0x49
 	RTM_DELCHAIN                                = 0x65
 	RTM_DELLINK                                 = 0x11
+	RTM_DELLINKPROP                             = 0x6d
 	RTM_DELMDB                                  = 0x55
 	RTM_DELNEIGH                                = 0x1d
 	RTM_DELNETCONF                              = 0x51
@@ -2011,6 +2022,7 @@ const (
 	RTM_GETCHAIN                                = 0x66
 	RTM_GETDCB                                  = 0x4e
 	RTM_GETLINK                                 = 0x12
+	RTM_GETLINKPROP                             = 0x6e
 	RTM_GETMDB                                  = 0x56
 	RTM_GETMULTICAST                            = 0x3a
 	RTM_GETNEIGH                                = 0x1e
@@ -2024,13 +2036,14 @@ const (
 	RTM_GETSTATS                                = 0x5e
 	RTM_GETTCLASS                               = 0x2a
 	RTM_GETTFILTER                              = 0x2e
-	RTM_MAX                                     = 0x6b
+	RTM_MAX                                     = 0x6f
 	RTM_NEWACTION                               = 0x30
 	RTM_NEWADDR                                 = 0x14
 	RTM_NEWADDRLABEL                            = 0x48
 	RTM_NEWCACHEREPORT                          = 0x60
 	RTM_NEWCHAIN                                = 0x64
 	RTM_NEWLINK                                 = 0x10
+	RTM_NEWLINKPROP                             = 0x6c
 	RTM_NEWMDB                                  = 0x54
 	RTM_NEWNDUSEROPT                            = 0x44
 	RTM_NEWNEIGH                                = 0x1c
@@ -2045,8 +2058,8 @@ const (
 	RTM_NEWSTATS                                = 0x5c
 	RTM_NEWTCLASS                               = 0x28
 	RTM_NEWTFILTER                              = 0x2c
-	RTM_NR_FAMILIES                             = 0x17
-	RTM_NR_MSGTYPES                             = 0x5c
+	RTM_NR_FAMILIES                             = 0x18
+	RTM_NR_MSGTYPES                             = 0x60
 	RTM_SETDCB                                  = 0x4f
 	RTM_SETLINK                                 = 0x13
 	RTM_SETNEIGHTBL                             = 0x43
@@ -2261,7 +2274,7 @@ const (
 	SOL_TLS                                     = 0x11a
 	SOL_X25                                     = 0x106
 	SOL_XDP                                     = 0x11b
-	SOMAXCONN                                   = 0x80
+	SOMAXCONN                                   = 0x1000
 	SO_ACCEPTCONN                               = 0x8000
 	SO_ATTACH_BPF                               = 0x34
 	SO_ATTACH_FILTER                            = 0x1a
@@ -2367,6 +2380,7 @@ const (
 	STATX_ATTR_ENCRYPTED                        = 0x800
 	STATX_ATTR_IMMUTABLE                        = 0x10
 	STATX_ATTR_NODUMP                           = 0x40
+	STATX_ATTR_VERITY                           = 0x100000
 	STATX_BASIC_STATS                           = 0x7ff
 	STATX_BLOCKS                                = 0x400
 	STATX_BTIME                                 = 0x800
@@ -2486,6 +2500,7 @@ const (
 	TCP_THIN_DUPACK                             = 0x11
 	TCP_THIN_LINEAR_TIMEOUTS                    = 0x10
 	TCP_TIMESTAMP                               = 0x18
+	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
 	TCP_WINDOW_CLAMP                            = 0xa
@@ -2580,6 +2595,10 @@ const (
 	TIPC_ADDR_MCAST                             = 0x1
 	TIPC_ADDR_NAME                              = 0x2
 	TIPC_ADDR_NAMESEQ                           = 0x1
+	TIPC_AEAD_ALG_NAME                          = 0x20
+	TIPC_AEAD_KEYLEN_MAX                        = 0x24
+	TIPC_AEAD_KEYLEN_MIN                        = 0x14
+	TIPC_AEAD_KEY_SIZE_MAX                      = 0x48
 	TIPC_CFG_SRV                                = 0x0
 	TIPC_CLUSTER_BITS                           = 0xc
 	TIPC_CLUSTER_MASK                           = 0xfff000
@@ -2612,6 +2631,7 @@ const (
 	TIPC_MCAST_REPLICAST                        = 0x86
 	TIPC_MEDIUM_IMPORTANCE                      = 0x1
 	TIPC_NODEID_LEN                             = 0x10
+	TIPC_NODELAY                                = 0x8a
 	TIPC_NODE_BITS                              = 0xc
 	TIPC_NODE_MASK                              = 0xfff
 	TIPC_NODE_OFFSET                            = 0x0

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
@@ -297,4 +297,5 @@ const (
 	SYS_FSMOUNT                = 432
 	SYS_FSPICK                 = 433
 	SYS_PIDFD_OPEN             = 434
+	SYS_CLONE3                 = 435
 )

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
@@ -592,7 +592,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2794,7 +2794,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
@@ -593,7 +593,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2809,7 +2809,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
@@ -596,7 +596,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2786,7 +2786,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
@@ -594,7 +594,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2788,7 +2788,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
@@ -595,7 +595,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2792,7 +2792,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
@@ -594,7 +594,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2791,7 +2791,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
@@ -594,7 +594,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2791,7 +2791,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
@@ -595,7 +595,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2792,7 +2792,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
@@ -595,7 +595,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2798,7 +2798,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
@@ -595,7 +595,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2798,7 +2798,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
@@ -594,7 +594,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2816,7 +2816,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
@@ -593,7 +593,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2812,7 +2812,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
@@ -597,7 +597,7 @@ const (
 	IFLA_NEW_IFINDEX        = 0x31
 	IFLA_MIN_MTU            = 0x32
 	IFLA_MAX_MTU            = 0x33
-	IFLA_MAX                = 0x33
+	IFLA_MAX                = 0x35
 	IFLA_INFO_KIND          = 0x1
 	IFLA_INFO_DATA          = 0x2
 	IFLA_INFO_XSTATS        = 0x3
@@ -2793,7 +2793,7 @@ const (
 	DEVLINK_ATTR_DPIPE_FIELD_MAPPING_TYPE     = 0x3c
 	DEVLINK_ATTR_PAD                          = 0x3d
 	DEVLINK_ATTR_ESWITCH_ENCAP_MODE           = 0x3e
-	DEVLINK_ATTR_MAX                          = 0x89
+	DEVLINK_ATTR_MAX                          = 0x8c
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_NONE     = 0x0
 	DEVLINK_DPIPE_FIELD_MAPPING_TYPE_IFINDEX  = 0x1
 	DEVLINK_DPIPE_MATCH_TYPE_FIELD_EXACT      = 0x0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -470,7 +470,7 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20190930215403-16217165b5de
 golang.org/x/lint
 golang.org/x/lint/golint
-# golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
+# golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9,7 +9,7 @@ code.cloudfoundry.org/go-loggregator
 code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2
 # code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a
 code.cloudfoundry.org/rfc5424
-# code.cloudfoundry.org/tlsconfig v0.0.0-20200125003142-b5ccaa4fedfc
+# code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3
 code.cloudfoundry.org/tlsconfig
 # contrib.go.opencensus.io/exporter/ocagent v0.6.0
 contrib.go.opencensus.io/exporter/ocagent

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -496,7 +496,7 @@ golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190423024810-112230192c58
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
-# golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
+# golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.2


### PR DESCRIPTION
Summary
--------------------------------------------------
3 dependencies updated, 1 dependency failed and 131 dependencies skipped in 5 attempts
 x failed github.com/onsi/ginkgo from v1.11.0 to v1.12.0
 x failed github.com/golang/protobuf from v1.3.2 to v1.3.3
 x failed github.com/onsi/gomega from v1.8.1 to v1.9.0
 x failed github.com/prometheus/client_golang from v1.2.1 to v1.4.0
 + updated golang.org/x/sys from v0.0.0-20200124204421-9fbb57f87de9 to v0.0.0-20200202164722-d101bd2416d5
 + updated code.cloudfoundry.org/tlsconfig from v0.0.0-20200125003142-b5ccaa4fedfc to v0.0.0-20200131000646-bbe0f8da39b3
 + updated golang.org/x/net from v0.0.0-20200114155413-6afb5195e5aa to v0.0.0-20200202094626-16171245cfb2