### PR TITLE
add function to wrap existing zap logger

### DIFF
--- a/src/pkg/logger/configure.go
+++ b/src/pkg/logger/configure.go
@@ -12,6 +12,10 @@ type Logger struct {
 	log *zap.Logger
 }
 
+func WrapLogger(l *zap.Logger) *Logger {
+	return &Logger{l}
+}
+
 func NewLogger(logLevel, app string) *Logger {
 	cfg := zap.Config{
 		Encoding:         "json",


### PR DESCRIPTION
This PR adds a function to the `logger` package to wrap an existing `zap.Logger` with `logger.Logger`.

