### PR TITLE
Support disabling serving via TLS for the CF Auth Proxy

### DIFF
--- a/src/cmd/cf-auth-proxy/app/cf_auth_proxy.go
+++ b/src/cmd/cf-auth-proxy/app/cf_auth_proxy.go
@@ -83,8 +83,6 @@ func (c *CFAuthProxyApp) Run() {
 	proxy := NewCFAuthProxy(
 		c.cfg.MetricStoreAddr,
 		c.cfg.Addr,
-		c.cfg.CertPath,
-		c.cfg.KeyPath,
 		c.cfg.ProxyCAPath,
 		c.log,
 		WithAuthMiddleware(middlewareProvider.Middleware),
@@ -94,6 +92,10 @@ func (c *CFAuthProxyApp) Run() {
 			c.cfg.MetricStoreClientTLS.CertPath,
 			c.cfg.MetricStoreClientTLS.KeyPath,
 			metricstore.COMMON_NAME,
+		),
+		WithServerTLS(
+			c.cfg.CertPath,
+			c.cfg.KeyPath,
 		),
 	)
 


### PR DESCRIPTION
This PR allows us to disable serving TLS in the CF Auth Proxy for the Log Store for use with K8s.