### PR TITLE
Auto Bump Dependencies 2020-02-24-000142

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/influxdata/flux v0.59.4 // indirect
-	github.com/influxdata/influxdb v1.7.9
+	github.com/influxdata/influxdb v1.7.10
 	github.com/influxdata/influxql v1.0.1
 	github.com/influxdata/roaring v0.4.12 // indirect
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -215,7 +215,7 @@ github.com/hpcloud/tail/ratelimiter
 github.com/hpcloud/tail/util
 github.com/hpcloud/tail/watch
 github.com/hpcloud/tail/winfile
-# github.com/influxdata/influxdb v1.7.9 => github.com/attack/influxdb v1.7.9-0.20191029173138-5bd71457cbd5
+# github.com/influxdata/influxdb v1.7.10 => github.com/attack/influxdb v1.7.9-0.20191029173138-5bd71457cbd5
 github.com/influxdata/influxdb/logger
 github.com/influxdata/influxdb/models
 github.com/influxdata/influxdb/monitor/diagnostics


### PR DESCRIPTION
Summary
--------------------------------------------------
1 dependency updated, 4 dependencies failed and 137 dependencies skipped in 9 attempts
 x failed golang.org/x/net from v0.0.0-20200202094626-16171245cfb2 to v0.0.0-20200222125558-5a598a2470a0
 x failed golang.org/x/sys from v0.0.0-20200202164722-d101bd2416d5 to v0.0.0-20200223170610-d5e6a3e2c0ae
 x failed github.com/golang/protobuf from v1.3.2 to v1.3.3
 x failed go.uber.org/zap from v1.13.0 to v1.14.0
 x failed github.com/onsi/ginkgo from v1.11.0 to v1.12.0
 x failed github.com/go-kit/kit from v0.9.0 to v0.10.0
 x failed github.com/onsi/gomega from v1.8.1 to v1.9.0
 x failed github.com/prometheus/client_golang from v1.2.1 to v1.4.1
 + updated github.com/influxdata/influxdb from v1.7.9 to v1.7.10