### PR TITLE
Do not use TLS in leanstreams if passed a nil tls.Config

### DIFF
--- a/src/pkg/leanstreams/leanstreams_test.go
+++ b/src/pkg/leanstreams/leanstreams_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/cloudfoundry/metric-store-release/src/internal/testing"
+	sharedtls "github.com/cloudfoundry/metric-store-release/src/internal/tls"
 	. "github.com/cloudfoundry/metric-store-release/src/pkg/leanstreams"
 	"github.com/cloudfoundry/metric-store-release/src/pkg/leanstreams/test/message"
-	sharedtls "github.com/cloudfoundry/metric-store-release/src/internal/tls"
 	"github.com/golang/protobuf/proto"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -52,7 +52,10 @@ func (tc *leanstreamsTestContext) Callback(data []byte) error {
 	tc.Lock()
 
 	msg := &message.Note{}
-	proto.Unmarshal(data, msg)
+	err := proto.Unmarshal(data, msg)
+	if err != nil {
+		panic(err)
+	}
 	comment := *msg.Comment
 
 	tc.MessageCommentsReceived = append(tc.MessageCommentsReceived, comment)
@@ -126,20 +129,72 @@ var _ = Describe("Leanstreams", func() {
 		return str[:len]
 	}
 
-	It("Secure writes to a connection are successfully read by the listener", func() {
-		tc, cleanup := setup()
-		defer cleanup()
+	Context("with TLS configured", func() {
+		It("Secure writes to a connection are successfully read by the listener", func() {
+			tc, cleanup := setup()
+			defer cleanup()
 
-		n, err := tc.Write("This is an example message")
-		Expect(n).To(Equal(60))
-		Expect(err).ToNot(HaveOccurred())
-		tc.WaitForResults()
+			n, err := tc.Write("This is an example message")
+			Expect(n).To(Equal(60))
+			Expect(err).ToNot(HaveOccurred())
+			tc.WaitForResults()
 
-		receivedData := tc.Results()[0]
-		Expect(receivedData).To(Equal("This is an example message"))
+			receivedData := tc.Results()[0]
+			Expect(receivedData).To(Equal("This is an example message"))
 
-		_, err = tc.Write("This is an example message")
-		Expect(err).ToNot(HaveOccurred())
+			_, err = tc.Write("This is an example message")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("without TLS configured", func() {
+		var setup = func() (tc *leanstreamsTestContext, cleanup func()) {
+			tc = &leanstreamsTestContext{}
+
+			maxMessageSize := 100
+			listenConfig := TCPListenerConfig{
+				MaxMessageSize: maxMessageSize,
+				Logger:         log.New(GinkgoWriter, "leanstreams", log.LstdFlags),
+				Address:        ":0",
+				Callback:       tc.Callback,
+			}
+			listener, err := ListenTCP(listenConfig)
+			if err != nil {
+				log.Fatal(err)
+			}
+			listener.StartListeningAsync()
+			tc.Listener = listener
+
+			writeConfig := TCPClientConfig{
+				MaxMessageSize: maxMessageSize,
+				Address:        listener.Address,
+			}
+			connection, err := DialTCP(&writeConfig)
+			if err != nil {
+				log.Fatal(err)
+			}
+			tc.Client = connection
+
+			return tc, func() {
+				tc.Client.Close()
+			}
+		}
+
+		It("Secure writes to a connection are successfully read by the listener", func() {
+			tc, cleanup := setup()
+			defer cleanup()
+
+			n, err := tc.Write("This is an example message")
+			Expect(n).To(Equal(60))
+			Expect(err).ToNot(HaveOccurred())
+			tc.WaitForResults()
+
+			receivedData := tc.Results()[0]
+			Expect(receivedData).To(Equal("This is an example message"))
+
+			_, err = tc.Write("This is an example message")
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("When the listeners read buffer is overrun", func() {

--- a/src/pkg/leanstreams/tcpclient.go
+++ b/src/pkg/leanstreams/tcpclient.go
@@ -108,11 +108,20 @@ func (c *TCPClient) Open() error {
 		return err
 	}
 	// TODO: consider adding a timeout
-	secureConnection, err := tls.Dial("tcp", tcpAddr.String(), c.tlsConfig)
-	if err != nil {
-		return err
+	var conn net.Conn
+	if c.tlsConfig != nil {
+		conn, err = tls.Dial("tcp", tcpAddr.String(), c.tlsConfig)
+		if err != nil {
+			return err
+		}
+	} else {
+		conn, err = net.Dial("tcp", tcpAddr.String())
+		if err != nil {
+			return err
+		}
 	}
-	c.socket = secureConnection
+
+	c.socket = conn
 	return err
 }
 

--- a/src/pkg/leanstreams/tcplistener.go
+++ b/src/pkg/leanstreams/tcplistener.go
@@ -138,14 +138,20 @@ func (t *TCPListener) openSocket() error {
 	if err != nil {
 		return err
 	}
-	insecureConnection, err := net.ListenTCP("tcp", tcpAddr)
+
+	var conn net.Listener
+
+	conn, err = net.ListenTCP("tcp", tcpAddr)
 	if err != nil {
 		return err
 	}
-	secureConnection := tls.NewListener(insecureConnection, t.tlsConfig)
 
-	t.socket = secureConnection
-	t.Address = insecureConnection.Addr().String()
+	if t.tlsConfig != nil {
+		conn = tls.NewListener(conn, t.tlsConfig)
+	}
+
+	t.socket = conn
+	t.Address = conn.Addr().String()
 	return err
 }
 


### PR DESCRIPTION
In K8s we are using Istio sidecars to handle TLS termination. This PR allows us to pass in a nil `tls.Config` in order to disable TLS on both the client and server side in the `leanstreams` package.