### PR TITLE
nest indicators erb metadata deployment name under labels key

### DIFF
--- a/jobs/metric-store-nozzle/templates/indicators.yml.erb
+++ b/jobs/metric-store-nozzle/templates/indicators.yml.erb
@@ -3,7 +3,8 @@ apiVersion: indicatorprotocol.io/v1
 kind: IndicatorDocument
 
 metadata:
-  deployment: <%= spec.deployment %>
+  labels:
+    deployment: <%= spec.deployment %>
 
 spec:
   product:

--- a/jobs/metric-store/templates/indicators.yml.erb
+++ b/jobs/metric-store/templates/indicators.yml.erb
@@ -3,7 +3,8 @@ apiVersion: indicatorprotocol.io/v1
 kind: IndicatorDocument
 
 metadata:
-  deployment: <%= spec.deployment %>
+  labels:
+    deployment: <%= spec.deployment %>
 
 spec:
   product:


### PR DESCRIPTION
In order for monitoring-indicator-protocol to process the IndicatorDocuments with metric-store, the indicator-protocol `indicators.yml.erb` need to [match the schema of the indicator-format](https://github.com/pivotal/monitoring-indicator-protocol/wiki#indicator-format)

Full disclaimer, not 100% sure if this is the only thing that should change to be square with [indicator-protocol reference recommendations](https://github.com/pivotal/monitoring-indicator-protocol/wiki/Indicator-Document-Reference#metadatalabels), e.g. if it should have `source_id` or `origin` or `component`, like the [`monitoring-mysql-release`](https://github.com/cloudfoundry-incubator/mysql-monitoring-release/blob/6578edc251f48d890d90e7f0b6b06edbe06f23eb/jobs/mysql-metrics/templates/indicators.yml.erb#L8-L9), etc. Not sure what best practice is; some releases with `indicators` only do `deployment`, so ¯\\_(ツ)_/¯ apologies

feel free to close this PR and/or have someone else redo it, etc., thanks all