### PR TITLE
Fixes go routine leak causing 100% memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8 // indirect
 	github.com/dvsekhvalnov/jose2go v0.0.0-20180829124132-7f401d37b68a
 	github.com/emirpasic/gods v1.12.0
+	github.com/fortytw2/leaktest v1.3.0
 	github.com/glycerine/go-unsnap-stream v0.0.0-20190901134440-81cf024a9e0a // indirect
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/go-kit/kit v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/vendor/github.com/fortytw2/leaktest/.travis.yml
+++ b/vendor/github.com/fortytw2/leaktest/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+go:
+ - 1.8
+ - 1.9
+ - "1.10"
+ - "1.11"
+ - tip
+
+script:
+ - go test -v -race -parallel 5 -coverprofile=coverage.txt -covermode=atomic ./
+ - go test github.com/fortytw2/leaktest -run ^TestEmptyLeak$
+
+before_install:
+  - pip install --user codecov
+after_success:
+  - codecov

--- a/vendor/github.com/fortytw2/leaktest/LICENSE
+++ b/vendor/github.com/fortytw2/leaktest/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/fortytw2/leaktest/README.md
+++ b/vendor/github.com/fortytw2/leaktest/README.md
@@ -1,0 +1,64 @@
+## Leaktest [![Build Status](https://travis-ci.org/fortytw2/leaktest.svg?branch=master)](https://travis-ci.org/fortytw2/leaktest) [![codecov](https://codecov.io/gh/fortytw2/leaktest/branch/master/graph/badge.svg)](https://codecov.io/gh/fortytw2/leaktest) [![Sourcegraph](https://sourcegraph.com/github.com/fortytw2/leaktest/-/badge.svg)](https://sourcegraph.com/github.com/fortytw2/leaktest?badge) [![Documentation](https://godoc.org/github.com/fortytw2/gpt?status.svg)](http://godoc.org/github.com/fortytw2/leaktest)
+
+Refactored, tested variant of the goroutine leak detector found in both
+`net/http` tests and the `cockroachdb` source tree.
+
+Takes a snapshot of running goroutines at the start of a test, and at the end -
+compares the two and _voila_. Ignores runtime/sys goroutines. Doesn't play nice
+with `t.Parallel()` right now, but there are plans to do so.
+
+### Installation
+
+Go 1.7+
+
+```
+go get -u github.com/fortytw2/leaktest
+```
+
+Go 1.5/1.6 need to use the tag `v1.0.0`, as newer versions depend on
+`context.Context`.
+
+### Example
+
+These tests fail, because they leak a goroutine
+
+```go
+// Default "Check" will poll for 5 seconds to check that all
+// goroutines are cleaned up
+func TestPool(t *testing.T) {
+    defer leaktest.Check(t)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+
+// Helper function to timeout after X duration
+func TestPoolTimeout(t *testing.T) {
+    defer leaktest.CheckTimeout(t, time.Second)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+
+// Use Go 1.7+ context.Context for cancellation
+func TestPoolContext(t *testing.T) {
+    ctx, _ := context.WithTimeout(context.Background(), time.Second)
+    defer leaktest.CheckContext(ctx, t)()
+
+    go func() {
+        for {
+            time.Sleep(time.Second)
+        }
+    }()
+}
+```
+
+## LICENSE
+
+Same BSD-style as Go, see LICENSE

--- a/vendor/github.com/fortytw2/leaktest/leaktest.go
+++ b/vendor/github.com/fortytw2/leaktest/leaktest.go
@@ -1,0 +1,153 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package leaktest provides tools to detect leaked goroutines in tests.
+// To use it, call "defer leaktest.Check(t)()" at the beginning of each
+// test that may use goroutines.
+// copied out of the cockroachdb source tree with slight modifications to be
+// more re-useable
+package leaktest
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type goroutine struct {
+	id    uint64
+	stack string
+}
+
+type goroutineByID []*goroutine
+
+func (g goroutineByID) Len() int           { return len(g) }
+func (g goroutineByID) Less(i, j int) bool { return g[i].id < g[j].id }
+func (g goroutineByID) Swap(i, j int)      { g[i], g[j] = g[j], g[i] }
+
+func interestingGoroutine(g string) (*goroutine, error) {
+	sl := strings.SplitN(g, "\n", 2)
+	if len(sl) != 2 {
+		return nil, fmt.Errorf("error parsing stack: %q", g)
+	}
+	stack := strings.TrimSpace(sl[1])
+	if strings.HasPrefix(stack, "testing.RunTests") {
+		return nil, nil
+	}
+
+	if stack == "" ||
+		// Ignore HTTP keep alives
+		strings.Contains(stack, ").readLoop(") ||
+		strings.Contains(stack, ").writeLoop(") ||
+		// Below are the stacks ignored by the upstream leaktest code.
+		strings.Contains(stack, "testing.Main(") ||
+		strings.Contains(stack, "testing.(*T).Run(") ||
+		strings.Contains(stack, "runtime.goexit") ||
+		strings.Contains(stack, "created by runtime.gc") ||
+		strings.Contains(stack, "interestingGoroutines") ||
+		strings.Contains(stack, "runtime.MHeap_Scavenger") ||
+		strings.Contains(stack, "signal.signal_recv") ||
+		strings.Contains(stack, "sigterm.handler") ||
+		strings.Contains(stack, "runtime_mcall") ||
+		strings.Contains(stack, "goroutine in C code") {
+		return nil, nil
+	}
+
+	// Parse the goroutine's ID from the header line.
+	h := strings.SplitN(sl[0], " ", 3)
+	if len(h) < 3 {
+		return nil, fmt.Errorf("error parsing stack header: %q", sl[0])
+	}
+	id, err := strconv.ParseUint(h[1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing goroutine id: %s", err)
+	}
+
+	return &goroutine{id: id, stack: strings.TrimSpace(g)}, nil
+}
+
+// interestingGoroutines returns all goroutines we care about for the purpose
+// of leak checking. It excludes testing or runtime ones.
+func interestingGoroutines(t ErrorReporter) []*goroutine {
+	buf := make([]byte, 2<<20)
+	buf = buf[:runtime.Stack(buf, true)]
+	var gs []*goroutine
+	for _, g := range strings.Split(string(buf), "\n\n") {
+		gr, err := interestingGoroutine(g)
+		if err != nil {
+			t.Errorf("leaktest: %s", err)
+			continue
+		} else if gr == nil {
+			continue
+		}
+		gs = append(gs, gr)
+	}
+	sort.Sort(goroutineByID(gs))
+	return gs
+}
+
+// ErrorReporter is a tiny subset of a testing.TB to make testing not such a
+// massive pain
+type ErrorReporter interface {
+	Errorf(format string, args ...interface{})
+}
+
+// Check snapshots the currently-running goroutines and returns a
+// function to be run at the end of tests to see whether any
+// goroutines leaked, waiting up to 5 seconds in error conditions
+func Check(t ErrorReporter) func() {
+	return CheckTimeout(t, 5*time.Second)
+}
+
+// CheckTimeout is the same as Check, but with a configurable timeout
+func CheckTimeout(t ErrorReporter, dur time.Duration) func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	fn := CheckContext(ctx, t)
+	return func() {
+		timer := time.AfterFunc(dur, cancel)
+		fn()
+		// Remember to clean up the timer and context
+		timer.Stop()
+		cancel()
+	}
+}
+
+// CheckContext is the same as Check, but uses a context.Context for
+// cancellation and timeout control
+func CheckContext(ctx context.Context, t ErrorReporter) func() {
+	orig := map[uint64]bool{}
+	for _, g := range interestingGoroutines(t) {
+		orig[g.id] = true
+	}
+	return func() {
+		var leaked []string
+		for {
+			select {
+			case <-ctx.Done():
+				t.Errorf("leaktest: timed out checking goroutines")
+			default:
+				leaked = make([]string, 0)
+				for _, g := range interestingGoroutines(t) {
+					if !orig[g.id] {
+						leaked = append(leaked, g.stack)
+					}
+				}
+				if len(leaked) == 0 {
+					return
+				}
+				// don't spin needlessly
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			break
+		}
+		for _, g := range leaked {
+			t.Errorf("leaktest: leaked goroutine: %v", g)
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,6 +108,8 @@ github.com/emirpasic/gods/containers
 github.com/emirpasic/gods/trees
 github.com/emirpasic/gods/trees/avltree
 github.com/emirpasic/gods/utils
+# github.com/fortytw2/leaktest v1.3.0
+github.com/fortytw2/leaktest
 # github.com/fsnotify/fsnotify v1.4.7
 github.com/fsnotify/fsnotify
 # github.com/glycerine/go-unsnap-stream v0.0.0-20190901134440-81cf024a9e0a


### PR DESCRIPTION
This PR fixes an issue the log-store encountered where a process using the leanstreams server consumes all memory. 

### Background
We saw a large number of these errors occurring from TCPServer `Read`:
```
... Message is too long: x bytes
```
The "message too long" error case was fixed in one of our releases, but 100% of memory would end up being consumed. Using `pprof`, we were able to determine that the leak was coming from within the leanstreams package:
```
File: log-store
      ...
      flat  flat%   sum%        cum   cum%
   15.45GB 94.89% 94.89%    15.45GB 94.89%  github.com/cloudfoundry/metric-store-release/src/pkg/leanstreams.newTCPServer
      ...
```

The test for this introduces a new testing package, [fortytw2/leaktest](https://github.com/fortytw2/leaktest). Running the test shows leaking go routines within TCPListener `readLoop`.

In this case where 
```go
msgLen, err := conn.Read(dataBuffer)
```
returns an error (since the message length is too long, signaling the slice is overrun), the go routine that _should_ close the TCPServer is never selected and hangs causing the server's allocated memory to never be released. Instead, we defer closing the server so that anytime `readLoop` returns, we appropriately close the server and free the memory.

Feel free to ask us any questions on this!

Signed-off-by: Glenn Oppegard <goppegard@pivotal.io>
Signed-off-by: Brady Love <blove@pivotal.io>