### PR TITLE
Auto Bump Dependencies 2020-06-21-230138

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	google.golang.org/grpc v1.29.0
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
-	k8s.io/api v0.17.5
+	k8s.io/api v0.17.7
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.17.5
 	sigs.k8s.io/yaml v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1288,7 +1288,10 @@ honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.17.5 h1:EkVieIbn1sC8YCDwckLKLpf+LoVofXYW72+LTZWo4aQ=
 k8s.io/api v0.17.5/go.mod h1:0zV5/ungglgy2Rlm3QK8fbxkXVs+BSJWpJP/+8gUVLY=
+k8s.io/api v0.17.7 h1:mvPe3zP7J8d5iRnsv3B/ddkvR+o+uoQluSAIFn7ySYo=
+k8s.io/api v0.17.7/go.mod h1:xL40O2BS4IEyvZVKVh6oaN4K5R5ndH8t42Rr7XL+C0k=
 k8s.io/apimachinery v0.17.5/go.mod h1:ioIo1G/a+uONV7Tv+ZmCbMG1/a3kVw5YcDdncd8ugQ0=
+k8s.io/apimachinery v0.17.7/go.mod h1:Lg8zZ5iC/O8UjCqW6DNhcQG2m4TdjF9kwG3891OWbbA=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/client-go v0.17.5 h1:Sm/9AQ415xPAX42JLKbJZnreXFgD2rVfDUDwOTm0gzA=
@@ -1304,6 +1307,8 @@ k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDN
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/kube-openapi v0.0.0-20200316234421-82d701f24f9d h1:jocF7XFucw2pEiv2wS7wk2FRFCjDFGV1oa4TMs0SAT0=
 k8s.io/kube-openapi v0.0.0-20200316234421-82d701f24f9d/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
+k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29 h1:NeQXVJ2XFSkRoPzRo8AId01ZER+j8oV4SZADT4iBOXQ=
+k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM3cOgIqGivxkwSWIWT5YdsDbeAOaU=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f h1:GiPwtSzdP43eI1hpPCbROQCCIgCuiMMNF8YUVLF3vJo=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 h1:Ly1Oxdu5p5ZFmiVT71LFgeZETvMfZ1iBIGeOenT2JeM=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -657,7 +657,7 @@ gopkg.in/tomb.v1
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 gopkg.in/yaml.v3
-# k8s.io/api v0.17.5
+# k8s.io/api v0.17.7
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1


### PR DESCRIPTION
Summary
--------------------------------------------------
1 dependency updated, 8 dependencies failed and 178 dependencies skipped in 15 attempts
 x failed golang.org/x/sys from v0.0.0-20200420163511-1957bb5e6d1f to v0.0.0-20200620081246-981b61492c35
 x failed gopkg.in/yaml.v3 from v3.0.0-20200313102051-9f266ea9e77c to v3.0.0-20200615113413-eeeca48fe776
 x failed github.com/onsi/ginkgo from v1.12.1 to v1.13.0
 x failed github.com/onsi/ginkgo from v1.12.1 to v1.12.3
 x failed k8s.io/apimachinery from v0.18.2 to v0.18.4
 x failed go.uber.org/zap from v1.14.1 to v1.15.0
 x failed golang.org/x/net from v0.0.0-20200520004742-59133d7f0dd7 to v0.0.0-20200602114024-627f9648deb9
 x failed github.com/json-iterator/go from v1.1.9 to v1.1.10
 x failed github.com/prometheus/client_golang from v1.5.1 to v1.7.0
 x failed k8s.io/client-go from v0.17.5 to v11.0.0+incompatible
 x failed k8s.io/client-go from v0.17.5 to v0.18.4
 x failed k8s.io/client-go from v0.17.5 to v0.17.7
 x failed github.com/prometheus/common from v0.9.1 to v0.10.0
 x failed k8s.io/api from v0.17.5 to v0.18.4
 + updated k8s.io/api from v0.17.5 to v0.17.7