### PR TITLE
Auto Bump Golang Release v0.146.0

### DIFF
--- a/.final_builds/packages/golang-1-linux/index.yml
+++ b/.final_builds/packages/golang-1-linux/index.yml
@@ -1,0 +1,6 @@
+builds:
+  c99f41ac9ed5cc73cf3cd00e320e119572c01a4a2a9857ceac7895ea27ef4965:
+    version: c99f41ac9ed5cc73cf3cd00e320e119572c01a4a2a9857ceac7895ea27ef4965
+    blobstore_id: 1dfc734e-5373-454c-6ce9-93ab54cc4fe5
+    sha1: sha256:11dc70255fb06ad2ab334307ddbc395238672108dab73ad7e6ce8e6f45ced075
+format-version: "2"

--- a/packages/golang-1-linux/spec.lock
+++ b/packages/golang-1-linux/spec.lock
@@ -1,2 +1,2 @@
 name: golang-1-linux
-fingerprint: bcf5419ffb1fd9657c2de80b44ac040970f99dff95418a32b7e0e1406747a89a
+fingerprint: c99f41ac9ed5cc73cf3cd00e320e119572c01a4a2a9857ceac7895ea27ef4965


### PR DESCRIPTION
bump to use go1.22.0