### PR TITLE
Auto Bump Golang Release v0.145.0

### DIFF
--- a/.final_builds/packages/golang-1-linux/index.yml
+++ b/.final_builds/packages/golang-1-linux/index.yml
@@ -1,0 +1,6 @@
+builds:
+  bcf5419ffb1fd9657c2de80b44ac040970f99dff95418a32b7e0e1406747a89a:
+    version: bcf5419ffb1fd9657c2de80b44ac040970f99dff95418a32b7e0e1406747a89a
+    blobstore_id: ed638a5b-0f79-4bd4-4d11-02d29878b02d
+    sha1: sha256:ccf2dcc274c89cbffaf8c01c1919cc1e45e6a7fbc9cfa7701cb8c3d673558149
+format-version: "2"


### PR DESCRIPTION
bump to use go1.21.7