### PR TITLE
remove excess print lines and save context

### DIFF
--- a/src/internal/nozzle/metric_service.go
+++ b/src/internal/nozzle/metric_service.go
@@ -12,10 +12,10 @@ import (
 
 	_ "google.golang.org/grpc/encoding/gzip"
 
+	"context"
 	"github.com/cloudfoundry/metric-store-release/src/pkg/logger"
 	metricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	otm "go.opentelemetry.io/proto/otlp/metrics/v1"
-	"golang.org/x/net/context"
 )
 
 type MetricService struct {
@@ -190,7 +190,6 @@ func (s *MetricService) createPointsFromMetric(metric *otm.Metric, dataPoints []
 
 		val, err := s.getPointValue(rp)
 		if err != nil {
-			s.log.Info("bad type for gauge data rp")
 			continue
 		}
 		point := &rpc.Point{
@@ -201,7 +200,6 @@ func (s *MetricService) createPointsFromMetric(metric *otm.Metric, dataPoints []
 		}
 		s.metrics.Inc(metrics.OtelIngressMetricsTotal)
 
-		s.log.Log("Point:", point)
 		points = append(points, point)
 	}
 

--- a/src/internal/nozzle/nozzle.go
+++ b/src/internal/nozzle/nozzle.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cloudfoundry/metric-store-release/src/pkg/rpc"
 
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Nozzle reads envelopes and writes points to metric-store.

--- a/src/internal/nozzle/otel_server.go
+++ b/src/internal/nozzle/otel_server.go
@@ -1,11 +1,12 @@
 package nozzle
 
 import (
+	"context"
 	"crypto/tls"
 	metricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"go.uber.org/zap"
-	"golang.org/x/net/context"
+
 	_ "google.golang.org/grpc/encoding/gzip"
 	"net"
 	"time"
@@ -71,6 +72,7 @@ func NewOtelServer(
 	ts *TraceService,
 ) *OtelServer {
 
+	ctx, cancel := context.WithCancel(context.Background())
 	// Initialize the gRPC server and register the metric service
 	grpcServer := grpc.NewServer()
 
@@ -80,6 +82,10 @@ func NewOtelServer(
 		log:        log,
 		ms:         ms,
 		ts:         ts,
+
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}, 1),
 	}
 }
 

--- a/src/internal/nozzle/rollup/counter.go
+++ b/src/internal/nozzle/rollup/counter.go
@@ -30,7 +30,6 @@ func NewCounterRollup(log *logger.Logger, nodeIndex string, rollupTags []string)
 
 func (r *counterRollup) Record(sourceId string, tags map[string]string, value int64) {
 	key := keyFromTags(r.rollupTags, sourceId, tags)
-	r.log.Log("msg", "CounterRollup: Record with key", "key", key)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -50,7 +49,6 @@ func (r *counterRollup) Rollup(timestamp int64) []*PointsBatch {
 		if err != nil {
 			continue
 		}
-		r.log.Log("msg", "CounterRollup: Rollup with ts", "timestamp", timestamp, "key", k, "value", float64(r.counters[k]))
 
 		countPoint := &rpc.Point{
 			Name:      GorouterHttpMetricName + "_total",
@@ -58,7 +56,6 @@ func (r *counterRollup) Rollup(timestamp int64) []*PointsBatch {
 			Value:     float64(r.counters[k]),
 			Labels:    labels,
 		}
-		r.log.Log("msg", "CounterRollup", "counter", countPoint)
 
 		batches = append(batches, &PointsBatch{
 			Points: []*rpc.Point{countPoint},

--- a/src/internal/nozzle/rollup/histogram.go
+++ b/src/internal/nozzle/rollup/histogram.go
@@ -34,8 +34,6 @@ func NewHistogramRollup(log *logger.Logger, nodeIndex string, rollupTags []strin
 }
 
 func (r *histogramRollup) Record(sourceId string, tags map[string]string, value int64) {
-	r.log.Log("msg", "histogramRollup.Record", "sourceId", sourceId, "value", value)
-
 	key := keyFromTags(r.rollupTags, sourceId, tags)
 
 	r.mu.Lock()
@@ -53,7 +51,6 @@ func (r *histogramRollup) Record(sourceId string, tags map[string]string, value 
 }
 
 func (r *histogramRollup) Rollup(timestamp int64) []*PointsBatch {
-	r.log.Log("msg", "histogramRollup.Rollup:", "vars", timestamp)
 	var batches []*PointsBatch
 
 	r.mu.Lock()
@@ -69,7 +66,13 @@ func (r *histogramRollup) Rollup(timestamp int64) []*PointsBatch {
 		}
 
 		m := &dto.Metric{}
-		_ = r.histograms[k].Write(m)
+		err = r.histograms[k].Write(m)
+		if err != nil {
+			r.log.Info(
+				"error writing to histogram",
+				logger.Error(err),
+			)
+		}
 		histogram := m.GetHistogram()
 
 		for _, bucket := range histogram.Bucket {

--- a/src/internal/nozzle/trace_service.go
+++ b/src/internal/nozzle/trace_service.go
@@ -14,7 +14,7 @@ import (
 
 	_ "google.golang.org/grpc/encoding/gzip"
 
-	"golang.org/x/net/context"
+	"context"
 
 	tracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	ot "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -113,7 +113,7 @@ func (s *TraceService) StartListening() {
 		close(s.done)
 	}()
 
-	s.log.Info("starting trace service")
+	s.log.Info("Starting trace service")
 
 	go s.timerProcessor()
 	go s.timerRollup()
@@ -146,9 +146,6 @@ func (s *TraceService) convertToSpan(sp *ot.Span) *rpc.Span {
 	}
 
 	if !s.allowListedTrace(tags) {
-		sourceId := tags["source_id"]
-		s.log.Log("msg", "TraceService.denied span:", "source_id", sourceId)
-
 		s.metrics.Inc(metrics.OtelDeniedSpansTotal)
 		return nil
 	}
@@ -222,7 +219,6 @@ func (s *TraceService) writeToChannelOrDiscard(points []*rpc.Point) []*rpc.Point
 func (s *TraceService) saveToStore() {
 	for {
 		points := <-s.pointBuffer
-		s.log.Info("TraceService: writing points to metrics store")
 		start := time.Now()
 		err := s.client.Write(points)
 		if err != nil {


### PR DESCRIPTION
Currently on shutdown we see stacktraces because the context in the NewOtelServer was never initialized. 