### PR TITLE
Add Kilnfile for GPP tile onboarding

### DIFF
--- a/tile/Kilnfile
+++ b/tile/Kilnfile
@@ -1,0 +1,26 @@
+release_sources:
+- type: artifactory
+  id: artifactory_compiled_releases
+  artifactory_host: $(variable "artifactory_host")
+  repo: $(variable "artifactory_repo")
+  username: $(variable "artifactory_username")
+  password: $(variable "artifactory_password") # api_key or identity token
+  publishable: true
+  path_template: compiled-releases/{{.Name}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz
+
+bake_configurations:
+- tile_name: metric-store
+  metadata_filepath: metadata.yml
+  forms_directories:
+  - forms
+  properties_directories:
+  - properties
+  instance_groups_directories:
+  - instance_groups
+  jobs_directories:
+  - jobs
+
+releases:
+- name: bpm
+- name: metric-store
+- name: routing

--- a/tile/Kilnfile
+++ b/tile/Kilnfile
@@ -8,19 +8,24 @@ release_sources:
   publishable: true
   path_template: compiled-releases/{{.Name}}/{{.Name}}-{{.Version}}-{{.StemcellOS}}-{{.StemcellVersion}}.tgz
 
+stemcell_criteria:
+  os: ubuntu-jammy
+  version: "*"
+
 bake_configurations:
 - tile_name: metric-store
-  metadata_filepath: metadata.yml
+  metadata_filepath: tile/metadata.yml
   forms_directories:
-  - forms
+  - tile/forms
   properties_directories:
-  - properties
+  - tile/properties
   instance_groups_directories:
-  - instance_groups
+  - tile/instance_groups
   jobs_directories:
-  - jobs
+  - tile/jobs
 
 releases:
 - name: bpm
 - name: metric-store
+  version: '>0-0'
 - name: routing

--- a/tile/Kilnfile.lock
+++ b/tile/Kilnfile.lock
@@ -4,7 +4,7 @@ releases:
   version: 0
 - name: metric-store
   remote_source: artifactory_compiled_releases
-  version: 0
+  version: 1.0.0
 - name: routing
   remote_source: artifactory_compiled_releases
   version: 0

--- a/tile/Kilnfile.lock
+++ b/tile/Kilnfile.lock
@@ -1,0 +1,13 @@
+releases:
+- name: bpm
+  remote_source: artifactory_compiled_releases
+  version: 0
+- name: metric-store
+  remote_source: artifactory_compiled_releases
+  version: 0
+- name: routing
+  remote_source: artifactory_compiled_releases
+  version: 0
+stemcell_criteria:
+  os: ubuntu-jammy
+  version: "1.44"


### PR DESCRIPTION
Adds tile/Kilnfile and tile/Kilnfile.lock, needed to register metric-store's tile with the Golden Path to Publish (GPP) pipeline.

- bake_configurations paths are repo-root-relative (tile/metadata.yml, tile/forms, etc.), matching how GPP's kiln bake actually resolves paths.
- stemcell_criteria added to the Kilnfile itself.
- metric-store's own release entry is opted into pre-release versions (version: '>0-0'), since our dev/pre-release builds wouldn't otherwise be visible to GPP; dependencies (bpm, routing) are left unconstrained since they're consumed as final releases only.
- Kilnfile.lock is a bootstrap placeholder. GPP's own automation resolves it to real versions once onboarding completes.

Verified locally that this builds cleanly: ran bosh create-release off this branch (produced metric-store-1.8.5+dev.1 without issue) and baked it into a tile with kiln bake alongside bpm and routing, producing a valid .pivotal.

Also worth noting for reviewers: this PR only adds two new files, tile/Kilnfile and tile/Kilnfile.lock. No changes to jobs/, packages/, src/, or any release/package spec. bosh create-release doesn't read anything under tile/, so these changes have no effect on the release content itself; they're purely GPP/kiln metadata used for tile baking.