### PR TITLE
fix: Adjust the label handling

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,6 +7,9 @@ jobs:
   auto-merge-job:
     name: Merge PR
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Merge
         uses: "pascalgn/automerge-action@fc8281547d24638fac1e4149bbde710cced773d1"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,51 @@
+name: Manage Labels
+on:
+  workflow_run:
+    workflows: ["Test Everything"]
+    types: [completed]
+jobs:
+  label-job:
+    name: Manage Labels
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: test-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const result = fs.readFileSync('test-result.txt', 'utf8').trim();
+            const labelName = 'tests-passed';
+            let pr = context.payload.workflow_run.pull_requests[0];
+            if (!pr) {
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+              });
+              pr = prs[0];
+            }
+            if (!pr) {
+              console.log('No PR associated with this workflow run');
+              return;
+            }
+            const issue_number = pr.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            if (result === 'success') {
+              await github.rest.issues.addLabels({ issue_number, owner, repo, labels: [labelName] });
+            } else {
+              try {
+                await github.rest.issues.removeLabel({ issue_number, owner, repo, name: labelName });
+              } catch (e) {
+                if (e.status !== 404) throw e;
+              }
+            }

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,12 +11,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: test-result
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.2'
         id: go
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -26,8 +26,10 @@ jobs:
       - name: Save test result
         if: always()
         run: echo "${{ job.status }}" > test-result.txt
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test-result
           path: test-result.txt
+          overwrite: 'true'
+          retention-days: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ jobs:
   test-job:
     name: All Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -17,43 +19,15 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: labels } = await github.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const labelToRemove = 'tests-passed';
-            const labelExists = labels.some(label => label.name === labelToRemove);
-            console.log("labelExists: ", labelExists);
-
-            if (labelExists) {
-              await github.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: labelToRemove
-              });
-            }
       - name: Run Tests
         run: |
           echo "Git HEAD at: $(git rev-parse HEAD)"
           ./scripts/test unit || ./scripts/test unit || ./scripts/test unit
-  success-job:
-    needs: test-job
-    name: Add Label
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v3
+      - name: Save test result
+        if: always()
+        run: echo "${{ job.status }}" > test-result.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            github.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['tests-passed']
-            })
+          name: test-result
+          path: test-result.txt

--- a/.github/workflows/vendoring.yml
+++ b/.github/workflows/vendoring.yml
@@ -13,12 +13,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26.2'
         id: go
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -37,7 +37,7 @@ jobs:
             git commit -m "Updating vendored dependencies"
             git push
           fi
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/vendoring.yml
+++ b/.github/workflows/vendoring.yml
@@ -9,6 +9,9 @@ jobs:
   vendor-job:
     name: Vendor
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## What changed

The `tests-passed` label workflow was broken for pull requests from forked repositories. Every run ended with a 403 from the GitHub API when trying to add or remove labels.

## Why it broke

GitHub restricts the `GITHUB_TOKEN` to read-only permissions for `pull_request` events that come from forks. This is a platform-level security boundary — no `permissions:` block in the workflow YAML can override it. The token simply cannot write labels when it was minted for a fork PR.

The previous workflow also had a secondary issue: `actions/github-script@v3` is outdated and was using the deprecated `github.issues.*` API style.

## How it's fixed

The fix splits label management into two separate workflows:

**`tests.yml` — Test Everything** (runs on `pull_request`)
- Checks out and runs the test suite with a read-only token, which is the correct and safe approach for untrusted fork code
- After the test run, writes `success` or `failure` to a file and uploads it as an artifact

**`label.yml` — Manage Labels** (runs on `workflow_run`)
- Triggered when `Test Everything` completes
- Runs in the context of the base repository, so the token always has write access regardless of where the PR came from
- Downloads the artifact, reads the result, and adds or removes the `tests-passed` label accordingly
- For fork PRs, GitHub omits the PR number from the `workflow_run` payload, so the workflow falls back to querying the API by head branch to find the open PR

## Works for both same-repo and fork PRs

- **Same-repo PRs**: GitHub includes the PR number directly in the `workflow_run` payload, so no fallback needed
- **Fork PRs**: The API fallback finds the PR by matching the head repository owner and branch name against open PRs