### PR TITLE
fix: stop interpolating stemcell version in metadata

### DIFF
--- a/tile/Kilnfile.lock
+++ b/tile/Kilnfile.lock
@@ -10,10 +10,10 @@ releases:
       remote_source: artifactory_compiled_releases
       remote_path: compiled-releases/metric-store/metric-store-1.8.5-ubuntu-jammy-1.1298.tgz
     - name: routing
-      sha1: d50154dca22669227acb94c23f17e63db6703592
-      version: 0.388.0
+      sha1: a12adc9b8fb145270a87243cbcfd94cd02318f78
+      version: 0.389.0
       remote_source: artifactory_compiled_releases
-      remote_path: compiled-releases/routing/routing-0.388.0-ubuntu-jammy-1.1298.tgz
+      remote_path: compiled-releases/routing/routing-0.389.0-ubuntu-jammy-1.1298.tgz
 stemcell_criteria:
     os: ubuntu-jammy
     version: "1.1298"

--- a/tile/metadata.yml
+++ b/tile/metadata.yml
@@ -20,7 +20,7 @@ requires_product_versions:
 
 stemcell_criteria:
   os: ubuntu-jammy
-  version: $( variable "stemcell_version" )
+  version: "1"
   requires_cpi: false
 
 releases:

--- a/tile/metadata.yml
+++ b/tile/metadata.yml
@@ -20,7 +20,7 @@ requires_product_versions:
 
 stemcell_criteria:
   os: ubuntu-jammy
-  version: "1"
+  version: "1.803"
   requires_cpi: false
 
 releases:


### PR DESCRIPTION
the existing ci doesn't provide this variable